### PR TITLE
Dialogue engine.  Moves dialogue forward if there is a next step,

### DIFF
--- a/client/engine/engine.js
+++ b/client/engine/engine.js
@@ -26,6 +26,7 @@ engine.teleportPlayer = function(roomTo, playerId) {
   Rooms.update({_id: roomAt},{$pull:{'mobs':playerId}});
   Rooms.update({_id: roomTo},{$push:{'mobs':playerId}});
   Player.update({_id: playerId},{$set:{'roomAt': roomTo}});
+  $('.dialogueResponse').hide()
 };
 
 engine.teleportMob = function(roomTo, mobId) {

--- a/pk001.css
+++ b/pk001.css
@@ -26,6 +26,12 @@
 	top:70%;
 	display:none;
 }
+.rclick {
+	cursor:default;
+}
+.rclick:hover{
+	background-color:yellow;
+}
 .exits{
 	position:fixed;
 	top:30%;
@@ -43,11 +49,12 @@
 	top:70%;
 }
 .exitTrue {
-	background-color:yellow;
 	cursor:default;
+	color:#009933;
+	font-weight:bold;
 }
 .exitFalse {
-	background-color:#999966;
+	font-style:italic;
 	cursor:default;
 }
 #menu {

--- a/pk001.js
+++ b/pk001.js
@@ -110,11 +110,13 @@ if (Meteor.isClient) {
     },
     'click .menuItemSpeak':function(){
     	var status = Dialogue.find({_id: Session.get('clickId')}).fetch()[0].status[0];
-    	console.log(status);
     	engine.echoPlayerEventLog(Dialogue.find({_id: Session.get('clickId')}).fetch()[0][status].text);
     	$('#menu').fadeToggle();
     	if (Dialogue.find({_id: Session.get('clickId')}).fetch()[0][status].response.length >= 1) {
     		$('.dialogueResponse').show()
+    	}
+    	if (Dialogue.find({_id: Session.get('clickId')}).fetch()[0][status].next >= 1) {
+    		Dialogue.update({_id: Session.get('clickId')}, {$set: {status: Dialogue.find({_id: Session.get('clickId')}).fetch()[0][status].next}});
     	}
     	//Makes the overflow scroll to the bottom.
     	$(".eventDisplay").scrollTop($(".eventDisplay")[0].scrollHeight);
@@ -135,14 +137,11 @@ if (Meteor.isClient) {
 	Template.dialogueResponse.events({
 		'click .rclick ':function() {
 			var currentMob = Session.get('clickId');
-			console.log(currentMob);
 			Session.set('rclick', this._id);
 			var responseClicked = Session.get('rclick');
-			console.log(Session.get('rclick'));
 			Dialogue.update({_id: currentMob}, {$set: {status: [Dialogue.find({_id: currentMob}).fetch()[0][responseClicked].next]}});
 			$('.dialogueResponse').hide();
 			engine.echoPlayerEventLog(Dialogue.find({_id: currentMob}).fetch()[0][responseClicked].text);
-
 		}
 	})
 


### PR DESCRIPTION
but no response is required.

Exits display. Css change, hopefully more readable.

Dialogue engine.  If a player moves out of room without a clicking
a response, removes it from the screen.  They can go back in and talk
to mob again to answer.
